### PR TITLE
Hide pagination buttons & fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,12 +154,14 @@ class Pagination {
         row = [];
 
         // Pagination Controls
-        row.push(getButton(this.messages.prev, `${this._callbackStr}-prev`));
-        if (this.isEnabledDeleteButton) {
-            row.push(getButton(this.messages.delete, `${this._callbackStr}-delete`));
+        if (this.totalPages > 1) {
+            row.push(getButton(this.messages.prev, `${this._callbackStr}-prev`));
+            if (this.isEnabledDeleteButton) {
+                row.push(getButton(this.messages.delete, `${this._callbackStr}-delete`));
+            }
+            row.push(getButton(this.messages.next, `${this._callbackStr}-next`));
+            keyboard.push(row);
         }
-        row.push(getButton(this.messages.next, `${this._callbackStr}-next`));
-        keyboard.push(row);
 
         // If needed add custom buttons
         if (this.inlineCustomButtons && typeof this.inlineCustomButtons === 'object') {

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class Pagination {
                 }
                 
                 let currentItem = items[i];
-                let textButton = (typeof currentItem[titleKey] !== 'undefined')
+                let textButton = (typeof currentItem[titleKey] !== 'undefined' && currentItem[titleKey] != '')
                     ? currentItem[titleKey]
                     : `Element #${i + 1}`;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf-pagination",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A simplified Telegraf plugin to provide users with a great interface.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
1. Added hiding pagination buttons when there is only one page with data.
2. And also fixed the situation when `telegraf` could throw an exception due to an empty button name (relevant when `isButtonMode = true`)